### PR TITLE
Enforce translator speed requirement and refine reception notes

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -77,7 +77,7 @@ moon:
   
   # Translation and collection requirements
   translation:
-    require_speed_advantage: false  # Remove speed prerequisite
+    require_speed_advantage: true   # Translator must be faster than both significators
     require_proper_sequence: true   # Must separate then apply
     require_reception: false        # Reception not mandatory
   

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -1987,17 +1987,17 @@ class EnhancedTraditionalHoraryJudgmentEngine:
             reception_with_quesited = reception_quesited_data["type"] != "none"
             
             # Reception helps but is not absolutely required for translation
-            reception_bonus = 0
-            reception_note = ""
             reception_display = ""
-            
-            if reception_with_querent or reception_with_quesited:
+            reception_bonus = 0
+
+            if reception_with_querent:
+                reception_display = reception_querent_data["display_text"]
                 reception_bonus = 10
-                reception_note = " with reception"
-                if reception_with_querent:
-                    reception_display = reception_querent_data["display_text"]
-                elif reception_with_quesited:
-                    reception_display = reception_quesited_data["display_text"]
+            elif reception_with_quesited:
+                reception_display = reception_quesited_data["display_text"]
+                reception_bonus = 10
+
+            reception_note = " with reception" if reception_display else " without reception"
                 
             # Base confidence from traditional sources
             confidence = 65 + reception_bonus
@@ -2013,8 +2013,9 @@ class EnhancedTraditionalHoraryJudgmentEngine:
             favorable = True
             hard = {Aspect.SQUARE, Aspect.OPPOSITION}
             if (querent_aspect.aspect in hard) or (quesited_aspect.aspect in hard):
-                favorable = False  # Hard aspects make translation strained
                 confidence -= 5
+                if not reception_display:
+                    favorable = False  # Hard aspects without reception are unfavorable
             
             # Calculate validation metrics for transparency
             translator_speed = abs(pos.speed)

--- a/backend/tests/test_translation_hard_aspects.py
+++ b/backend/tests/test_translation_hard_aspects.py
@@ -81,3 +81,69 @@ def test_translation_with_hard_aspect_unfavorable(monkeypatch, hard_aspect):
     assert result["found"]
     assert not result["favorable"]
     assert result["confidence"] == 60
+    assert "without reception" in result["sequence"]
+    assert result["reception"] == "none"
+
+
+def make_slow_chart() -> HoraryChart:
+    now = datetime.datetime.utcnow()
+    planets = {
+        Planet.VENUS: PlanetPosition(Planet.VENUS, 0, 0, 1, Sign.ARIES, 0, speed=1),
+        Planet.MARS: PlanetPosition(Planet.MARS, 0, 0, 7, Sign.LIBRA, 0, speed=1),
+        Planet.MERCURY: PlanetPosition(Planet.MERCURY, 0, 0, 2, Sign.TAURUS, 0, speed=0.5),
+    }
+    aspects = [
+        AspectInfo(
+            planet1=Planet.MERCURY,
+            planet2=Planet.VENUS,
+            aspect=Aspect.TRINE,
+            orb=5,
+            applying=False,
+        ),
+        AspectInfo(
+            planet1=Planet.MERCURY,
+            planet2=Planet.MARS,
+            aspect=Aspect.TRINE,
+            orb=5,
+            applying=True,
+        ),
+    ]
+    houses = [i * 30 for i in range(12)]
+    house_rulers = {1: Planet.VENUS, 7: Planet.MARS}
+    return HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=aspects,
+        houses=houses,
+        house_rulers=house_rulers,
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_translation_requires_speed_advantage(monkeypatch):
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+
+    monkeypatch.setattr(engine, "_is_aspect_within_orb_limits", lambda chart, aspect: True)
+    monkeypatch.setattr(
+        engine, "_validate_translation_sequence_timing", lambda chart, t, sep, app: True
+    )
+    monkeypatch.setattr(
+        engine, "_check_intervening_aspects", lambda chart, t, sep, app: []
+    )
+
+    class DummyReception:
+        @staticmethod
+        def calculate_comprehensive_reception(chart, planet, target):
+            return {"type": "none", "display_text": ""}
+
+    engine.reception_calculator = DummyReception()
+
+    chart = make_slow_chart()
+    result = engine._check_enhanced_translation_of_light(chart, Planet.VENUS, Planet.MARS)
+
+    assert not result["found"]


### PR DESCRIPTION
## Summary
- Require translation-of-light translator to be faster than both significators
- Clarify reception in translation sequences and mark hard-aspect, no-reception cases as unfavorable
- Add tests for slow translator rejection and hard-aspect translations without reception

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3965c7048324987528e84b269369